### PR TITLE
Added: hash navigation support

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,27 +1,25 @@
 <!DOCTYPE html>
 <html lang="hu">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vizzu - Presentation sample</title>
+    <style>
+      body {
+        padding: 0;
+        margin: 0;
+      }
 
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Vizzu - Presentation sample</title>
-  <style>
-    body {
-      padding: 0;
-      margin: 0;
-    }
+      vizzu-player {
+        width: 100vw;
+        height: 100vh;
+      }
+    </style>
+  </head>
 
-    vizzu-player {
-      width: 100vw;
-      height: 100vh;
-    }
-  </style>
-</head>
-
-<body>
-  <vizzu-player hash-navigation vizzu-url="https://vizzu-lib-main.storage.googleapis.com/lib/vizzu.js" controller custom-spinner="loadinganim.svg"></vizzu-player>
-  <script type="module" src="index.js" defer></script>
-</body>
-
+  <body>
+    <vizzu-player controller custom-spinner="loadinganim.svg"></vizzu-player>
+    <script type="module" src="index.js" defer></script>
+  </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,7 +20,7 @@
 </head>
 
 <body>
-  <vizzu-player controller custom-spinner="loadinganim.svg" vizzu-url="https://vizzu-lib-main.storage.googleapis.com/lib/vizzu.js"></vizzu-player>
+  <vizzu-player controller custom-spinner="loadinganim.svg"></vizzu-player>
   <script type="module" src="index.js" defer></script>
 </body>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,7 +20,7 @@
 </head>
 
 <body>
-  <vizzu-player controller custom-spinner="loadinganim.svg"></vizzu-player>
+  <vizzu-player vizzu-url="https://vizzu-lib-main.storage.googleapis.com/lib/vizzu.js" controller custom-spinner="loadinganim.svg"></vizzu-player>
   <script type="module" src="index.js" defer></script>
 </body>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,7 +20,7 @@
 </head>
 
 <body>
-  <vizzu-player controller custom-spinner="loadinganim.svg"></vizzu-player>
+  <vizzu-player controller custom-spinner="loadinganim.svg" vizzu-url="https://vizzu-lib-main.storage.googleapis.com/lib/vizzu.js"></vizzu-player>
   <script type="module" src="index.js" defer></script>
 </body>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,7 +20,7 @@
 </head>
 
 <body>
-  <vizzu-player vizzu-url="https://vizzu-lib-main.storage.googleapis.com/lib/vizzu.js" controller custom-spinner="loadinganim.svg"></vizzu-player>
+  <vizzu-player hash-navigation vizzu-url="https://vizzu-lib-main.storage.googleapis.com/lib/vizzu.js" controller custom-spinner="loadinganim.svg"></vizzu-player>
   <script type="module" src="index.js" defer></script>
 </body>
 

--- a/src/__mocks__/vizzu.js
+++ b/src/__mocks__/vizzu.js
@@ -1,3 +1,13 @@
+class Control {
+  constructor(animation) {
+    this._animation = animation;
+  }
+
+  store() {
+    return this._animation;
+  }
+}
+
 class Vizzu {
   constructor() {
     this._snapshot = {};
@@ -7,9 +17,11 @@ class Vizzu {
 
   off() {}
 
-  async animate() {
+  animate() {
     this._snapshot = [...arguments][0];
-    return Promise.resolve();
+    const anim = Promise.resolve("test1");
+    anim.activated = Promise.resolve(new Control([...arguments][0]));
+    return anim;
   }
 
   store() {

--- a/src/__tests__/assets/slides.js
+++ b/src/__tests__/assets/slides.js
@@ -30,12 +30,14 @@ const story = [
         config: configAssets.config4,
         style: styleAssets.style4,
         filter: dataFilterAssets.filter4,
+        animOptions: { duration: 1 },
       },
       [
         {
           config: configAssets.config1,
           style: styleAssets.style1,
           filter: dataFilterAssets.filter1,
+          animOptions: { duration: 1 },
         },
         {
           config: configAssets.config2,
@@ -83,6 +85,9 @@ const story = [
             config: configAssets.config4,
             style: styleAssets.style4,
           },
+          options: {
+            duration: 1,
+          },
         },
       ],
     ],
@@ -93,6 +98,9 @@ const story = [
             data: { filter: dataFilterAssets.filter1 },
             config: configAssets.config1,
             style: styleAssets.style1,
+          },
+          options: {
+            duration: 1,
           },
         },
         {
@@ -130,11 +138,45 @@ slides.push(
     [[[{ target: { data: {}, config: configAssets.config1 } }]]],
   ],
   [
+    "slides contain one slide with one step (object) with config and animOptions",
+    {
+      slides: [{ config: configAssets.config1, animOptions: { duration: 1 } }],
+    },
+    [
+      [
+        [
+          {
+            target: { data: {}, config: configAssets.config1 },
+            options: { duration: 1 },
+          },
+        ],
+      ],
+    ],
+  ],
+  [
     "slides contain one slide with one step (list) with config",
     {
       slides: [[{ config: configAssets.config1 }]],
     },
     [[[{ target: { data: {}, config: configAssets.config1 } }]]],
+  ],
+  [
+    "slides contain one slide with one step (list) with config and animOptions",
+    {
+      slides: [
+        [{ config: configAssets.config1, animOptions: { duration: 1 } }],
+      ],
+    },
+    [
+      [
+        [
+          {
+            target: { data: {}, config: configAssets.config1 },
+            options: { duration: 1 },
+          },
+        ],
+      ],
+    ],
   ],
   [
     "object contains style and slides contain one slide with one step (object) with style",

--- a/src/__tests__/assets/slides.js
+++ b/src/__tests__/assets/slides.js
@@ -49,50 +49,58 @@ const story = [
     [
       [
         {
-          data: { filter: dataFilterAssets.filter1 },
-          config: configAssets.config1,
-          style: styleAssets.style1,
+          target: {
+            data: { filter: dataFilterAssets.filter1 },
+            config: configAssets.config1,
+            style: styleAssets.style1,
+          },
         },
-      ],
-      [
         {
-          data: { filter: dataFilterAssets.filter2 },
-          config: configAssets.config2,
-          style: styleAssets.style2,
-        },
-      ],
-    ],
-    [
-      [
-        {
-          data: { filter: dataFilterAssets.filter3 },
-          config: configAssets.config3,
-          style: styleAssets.style3,
+          target: {
+            data: { filter: dataFilterAssets.filter2 },
+            config: configAssets.config2,
+            style: styleAssets.style2,
+          },
         },
       ],
     ],
     [
       [
         {
-          data: { filter: dataFilterAssets.filter4 },
-          config: configAssets.config4,
-          style: styleAssets.style4,
+          target: {
+            data: { filter: dataFilterAssets.filter3 },
+            config: configAssets.config3,
+            style: styleAssets.style3,
+          },
         },
       ],
     ],
     [
       [
         {
-          data: { filter: dataFilterAssets.filter1 },
-          config: configAssets.config1,
-          style: styleAssets.style1,
+          target: {
+            data: { filter: dataFilterAssets.filter4 },
+            config: configAssets.config4,
+            style: styleAssets.style4,
+          },
         },
       ],
+    ],
+    [
       [
         {
-          data: { filter: dataFilterAssets.filter2 },
-          config: configAssets.config2,
-          style: styleAssets.style2,
+          target: {
+            data: { filter: dataFilterAssets.filter1 },
+            config: configAssets.config1,
+            style: styleAssets.style1,
+          },
+        },
+        {
+          target: {
+            data: { filter: dataFilterAssets.filter2 },
+            config: configAssets.config2,
+            style: styleAssets.style2,
+          },
         },
       ],
     ],
@@ -119,14 +127,14 @@ slides.push(
     {
       slides: [{ config: configAssets.config1 }],
     },
-    [[[{ data: {}, config: configAssets.config1 }]]],
+    [[[{ target: { data: {}, config: configAssets.config1 } }]]],
   ],
   [
     "slides contain one slide with one step (list) with config",
     {
       slides: [[{ config: configAssets.config1 }]],
     },
-    [[[{ data: {}, config: configAssets.config1 }]]],
+    [[[{ target: { data: {}, config: configAssets.config1 } }]]],
   ],
   [
     "object contains style and slides contain one slide with one step (object) with style",
@@ -134,14 +142,14 @@ slides.push(
       style: styleAssets.style2,
       slides: [{ style: styleAssets.style1 }],
     },
-    [[[{ data: {}, style: styleAssets.style1 }]]],
+    [[[{ target: { data: {}, style: styleAssets.style1 } }]]],
   ],
   [
     "slides contain one slide with one step (object) with style",
     {
       slides: [{ style: styleAssets.style1 }],
     },
-    [[[{ data: {}, style: styleAssets.style1 }]]],
+    [[[{ target: { data: {}, style: styleAssets.style1 } }]]],
   ],
   [
     "object contains style and slides contain one slide with one step (list) with style",
@@ -149,14 +157,14 @@ slides.push(
       style: styleAssets.style2,
       slides: [[{ style: styleAssets.style1 }]],
     },
-    [[[{ data: {}, style: styleAssets.style1 }]]],
+    [[[{ target: { data: {}, style: styleAssets.style1 } }]]],
   ],
   [
     "slides contain one slide with one step (list) with style",
     {
       slides: [[{ style: styleAssets.style1 }]],
     },
-    [[[{ data: {}, style: styleAssets.style1 }]]],
+    [[[{ target: { data: {}, style: styleAssets.style1 } }]]],
   ],
   [
     "object contains data and slides contain one slide with one step (object) with filter",
@@ -168,9 +176,11 @@ slides.push(
       [
         [
           {
-            data: Object.assign({}, dataAssets.data1, {
-              filter: dataFilterAssets.filter1,
-            }),
+            target: {
+              data: Object.assign({}, dataAssets.data1, {
+                filter: dataFilterAssets.filter1,
+              }),
+            },
           },
         ],
       ],
@@ -181,7 +191,7 @@ slides.push(
     {
       slides: [{ filter: dataFilterAssets.filter1 }],
     },
-    [[[{ data: { filter: dataFilterAssets.filter1 } }]]],
+    [[[{ target: { data: { filter: dataFilterAssets.filter1 } } }]]],
   ],
   [
     "object contains style and slides contain one slide with one step (list) with filter",
@@ -193,9 +203,11 @@ slides.push(
       [
         [
           {
-            data: Object.assign({}, dataAssets.data1, {
-              filter: dataFilterAssets.filter1,
-            }),
+            target: {
+              data: Object.assign({}, dataAssets.data1, {
+                filter: dataFilterAssets.filter1,
+              }),
+            },
           },
         ],
       ],
@@ -206,7 +218,7 @@ slides.push(
     {
       slides: [[{ filter: dataFilterAssets.filter1 }]],
     },
-    [[[{ data: { filter: dataFilterAssets.filter1 } }]]],
+    [[[{ target: { data: { filter: dataFilterAssets.filter1 } } }]]],
   ]
 );
 
@@ -221,8 +233,8 @@ slides.push(
       ],
     },
     [
-      [[{ data: {}, config: configAssets.config1 }]],
-      [[{ config: configAssets.config2 }]],
+      [[{ target: { data: {}, config: configAssets.config1 } }]],
+      [[{ target: { config: configAssets.config2 } }]],
     ],
   ],
   [
@@ -234,8 +246,8 @@ slides.push(
       ],
     },
     [
-      [[{ data: {}, config: configAssets.config1 }]],
-      [[{ config: configAssets.config2 }]],
+      [[{ target: { data: {}, config: configAssets.config1 } }]],
+      [[{ target: { config: configAssets.config2 } }]],
     ],
   ]
 );

--- a/src/vizzu-player.js
+++ b/src/vizzu-player.js
@@ -32,9 +32,11 @@ class VizzuPlayer extends HTMLElement {
     }
 
     window.addEventListener("hashchange", () => {
-      const hashSlide = this._slideFromHash(this._slides.length);
-      if (this._currentSlide !== hashSlide) {
-        this.setSlide(hashSlide);
+      if (this.hashNavigation) {
+        const hashSlide = this._slideFromHash(this._slides.length);
+        if (this._currentSlide !== hashSlide) {
+          this.setSlide(hashSlide);
+        }
       }
     });
   }
@@ -54,6 +56,10 @@ class VizzuPlayer extends HTMLElement {
     if (this.debug) {
       console.log(...LOG_PREFIX, ...msg);
     }
+  }
+
+  get hashNavigation() {
+    return this.hasAttribute("hash-navigation");
   }
 
   get vizzuUrl() {
@@ -158,17 +164,24 @@ class VizzuPlayer extends HTMLElement {
     return hashSlide;
   }
 
+  get startSlide() {
+    const startSlide = +this.getAttribute("start-slide");
+    return startSlide ? startSlide - 1 : 0;
+  }
+
   get slides() {
     return this._slides;
   }
 
   set slides(slides) {
-    const hashSlide = this._slideFromHash(slides.slides.length);
-    if (hashSlide) {
-      this._currentSlide = hashSlide;
-    } else {
-      this._currentSlide = 0;
+    let startSlide = this.startSlide;
+    if (this.hashNavigation) {
+      const hashSlide = this._slideFromHash(slides.slides.length);
+      if (hashSlide) {
+        startSlide = hashSlide;
+      }
     }
+    this._currentSlide = startSlide;
     this._setSlides(slides);
   }
 
@@ -327,7 +340,9 @@ class VizzuPlayer extends HTMLElement {
     this._update(this._state);
 
     // update url hash
-    document.location.hash = `#${slide + 1}`;
+    if (this.hashNavigation) {
+      document.location.hash = `#${slide + 1}`;
+    }
   }
 
   next() {

--- a/src/vizzu-player.js
+++ b/src/vizzu-player.js
@@ -152,21 +152,27 @@ class VizzuPlayer extends HTMLElement {
   }
 
   _slideFromHash(length) {
-    let hashSlide = +document.location.hash.substring(1);
-    if (hashSlide) {
-      if (hashSlide < 0) {
-        hashSlide = 1 + length + (hashSlide % length);
+    const hashSlide = +document.location.hash.substring(1);
+
+    return this._normalizeSlideNumber(hashSlide, length);
+  }
+
+  _getStartSlide(length) {
+    const startSlide = +this.getAttribute("start-slide") || 0;
+
+    return this._normalizeSlideNumber(startSlide, length);
+  }
+
+  _normalizeSlideNumber(nr, length) {
+    if (nr) {
+      if (nr < 0) {
+        nr = (length + nr % length) % length;
       } else {
-        hashSlide = (hashSlide - 1) % length;
+        nr = (nr - 1) % length;
       }
     }
 
-    return hashSlide;
-  }
-
-  get startSlide() {
-    const startSlide = +this.getAttribute("start-slide");
-    return startSlide ? startSlide - 1 : 0;
+    return nr || 0;
   }
 
   get slides() {
@@ -174,7 +180,7 @@ class VizzuPlayer extends HTMLElement {
   }
 
   set slides(slides) {
-    let startSlide = this.startSlide;
+    let startSlide = this._getStartSlide(slides.slides.length);
     if (this.hashNavigation) {
       const hashSlide = this._slideFromHash(slides.slides.length);
       if (hashSlide) {

--- a/src/vizzu-player.js
+++ b/src/vizzu-player.js
@@ -312,7 +312,8 @@ class VizzuPlayer extends HTMLElement {
     return this.setSlide(this.length - 1);
   }
 
-  async seek(percent) { // TODO remove subslide concept
+  async seek(percent) {
+    // TODO remove subslide concept
     if (this.acquireLock()) {
       this._update(this._state);
       this.log(

--- a/src/vizzu-player.js
+++ b/src/vizzu-player.js
@@ -149,7 +149,7 @@ class VizzuPlayer extends HTMLElement {
     let hashSlide = +document.location.hash.substring(1);
     if (hashSlide) {
       if (hashSlide < 0) {
-        hashSlide = 1 + length + hashSlide % length;
+        hashSlide = 1 + length + (hashSlide % length);
       } else {
         hashSlide = (hashSlide - 1) % length;
       }

--- a/src/vizzu-player.js
+++ b/src/vizzu-player.js
@@ -106,12 +106,12 @@ class VizzuPlayer extends HTMLElement {
       const animParams = steps.map((step) => this._slideToAnimparams(step));
       this.log("animating", animParams);
       await this.vizzu.animate(animParams);
-      chartSteps.push([this.vizzu.store()]); // TODO - remove array
+      chartSteps.push(this.vizzu.store());
 
       convertedSlides.push(chartSteps);
     }
     if (convertedSlides.length) {
-      await this.vizzu.animate(...convertedSlides[0][0]);
+      await this.vizzu.animate(...convertedSlides[0]);
     }
     this.vizzu.off("animation-begin", seekToEnd);
 
@@ -122,7 +122,6 @@ class VizzuPlayer extends HTMLElement {
     return this._slides;
   }
 
-  // TODO
   set slides(slides) {
     this._currentSlide = 0;
     this._setSlides(slides);
@@ -198,28 +197,21 @@ class VizzuPlayer extends HTMLElement {
     return this.hasAttribute("controller");
   }
 
-  // TODO
   async _step(step) {
-    return await this.vizzu.animate(...step);
+    return await this.vizzu.animate(step);
   }
 
   // TODO proper exception handling to re-enable rendering and such
-  async _jump(cs, ss, percent) {
+  async _jump(cs, percent) {
     return new Promise((resolve) =>
       setTimeout(async () => {
-        this.log("jump to", cs, ss, percent);
-        const subSlide = this._slides[cs][ss];
+        this.log("jump to", cs, percent);
+        const subSlide = this._slides[cs];
         const seek = () => this._seekTo(percent);
 
         this.vizzu.feature("rendering", false);
         // animate to previous slide
-        if (ss > 0) {
-          const prevSubSlide = this._slides[cs][ss - 1];
-          const seekToEnd = () => this._seekToEnd();
-          this.vizzu.on("animation-begin", seekToEnd);
-          await this.vizzu.animate(...prevSubSlide);
-          this.vizzu.off("animation-begin", seekToEnd);
-        } else if (cs > 0) {
+        if (cs > 0) {
           const prevSlide = this._slides[cs - 1];
           const prevSubSlide = prevSlide[prevSlide.length - 1];
           const seekToEnd = () => this._seekToEnd();
@@ -256,7 +248,7 @@ class VizzuPlayer extends HTMLElement {
     return this._seekTo(100);
   }
 
-  async setSlide(slide, subSlide) {
+  async setSlide(slide) {
     if (this.length === 0 || !this.acquireLock()) {
       return;
     }
@@ -269,8 +261,7 @@ class VizzuPlayer extends HTMLElement {
     }
 
     if (typeof subSlide !== "undefined") {
-      this._subSlide = subSlide;
-      await this._step(this._slides[slide][subSlide]);
+      await this._step(this._slides[slide]);
     } else if (this._currentSlide - slide === 1) {
       // previous
       const cs = this._slides[this._currentSlide];

--- a/src/vizzu-player.js
+++ b/src/vizzu-player.js
@@ -166,7 +166,7 @@ class VizzuPlayer extends HTMLElement {
   _normalizeSlideNumber(nr, length) {
     if (nr) {
       if (nr < 0) {
-        nr = (length + nr % length) % length;
+        nr = (length + (nr % length)) % length;
       } else {
         nr = (nr - 1) % length;
       }


### PR DESCRIPTION
Fixes #26. (Depends on #25, but it's included here.)

Slides can be selected using the URL hash (# part), like: whatever.vizzu.com/presentation.html#4 selects slide 4.
Slide animation is played, but we can fix that later.

For hash navigation, add `hash-navigation` attribute to the `vizzu-player` element.

If you want to start the slideshow on a specific slide, use the `start-slide=<nr>` attribute.