### PR TITLE
VizzuUrl return undefined

### DIFF
--- a/src/vizzu-player.js
+++ b/src/vizzu-player.js
@@ -63,7 +63,6 @@ class VizzuPlayer extends HTMLElement {
   }
 
   get vizzuUrl() {
-    if (window.Vizzu) return undefined;
     return (
       this.getAttribute("vizzu-url") ||
       "https://cdn.jsdelivr.net/npm/vizzu@0.8/dist/vizzu.min.js"

--- a/src/vizzu-player.js
+++ b/src/vizzu-player.js
@@ -63,6 +63,7 @@ class VizzuPlayer extends HTMLElement {
   }
 
   get vizzuUrl() {
+    if (window.Vizzu) return undefined;
     return (
       this.getAttribute("vizzu-url") ||
       "https://cdn.jsdelivr.net/npm/vizzu@0.8/dist/vizzu.min.js"


### PR DESCRIPTION
The vizzuUrl function return undefined when the window.Vizzu is exists.